### PR TITLE
fix Deprecated message:

### DIFF
--- a/Provider/KeycloakResourceOwner.php
+++ b/Provider/KeycloakResourceOwner.php
@@ -17,7 +17,7 @@ class KeycloakResourceOwner implements ResourceOwnerInterface
      */
     protected $token;
 
-    public function __construct(array $response = [], AccessToken $token)
+    public function __construct(array $response, AccessToken $token)
     {
         $this->response = $response;
         $this->token = $token;


### PR DESCRIPTION
 Optional parameter $response declared before required parameter $token is implicitly treated as a required parameter